### PR TITLE
Font change

### DIFF
--- a/SSEthesisPreamble.sty
+++ b/SSEthesisPreamble.sty
@@ -13,8 +13,8 @@
 
 % FONTS
 % Garamond font for text and math
-\RequirePackage{garamondx}
-\RequirePackage[garamondx,cmbraces]{newtxmath}
+\RequirePackage{ebgaramond-maths}
+\RequirePackage[cmintegrals,cmbraces]{newtxmath}
 \RequirePackage{avant} % Avant Gothic for headings/captions
 
 \RequirePackage{lipsum} % to add filler text to template. Can remove.
@@ -42,7 +42,7 @@
 
 % ###################### MATH ##################################################
 \RequirePackage{amsmath}
-\RequirePackage{amssymb,amsfonts,mathrsfs,accents} % pdflatex
+\RequirePackage{amsfonts,mathrsfs,accents} % pdflatex
 %\RequirePackage[]{unicode-math} % xelatex
 
 % ###################### GRAPHICS ##############################################


### PR DESCRIPTION
`garamondx` package is obsolete and unnecessarily hard to install. Better use some other Garamond, e.g. [EB Garamond](https://tug.org/FontCatalogue/ebgaramond/). With EB Garamond, there is [no need for `amssymb`](https://pctex.com/kb/86.html).