### PR TITLE
Unnumbered dedication page

### DIFF
--- a/dissertation.tex
+++ b/dissertation.tex
@@ -79,6 +79,7 @@ This book was typeset by the author using \LaTeX.\par\bigskip
 
 % Dedication
 \cleardoublepage
+\thispagestyle{empty}
 \vspace*{45mm}
 \begin{center}
 \textit{To me}


### PR DESCRIPTION
In professionally edited books, the dedication is not numbered---at least not in the books that I have checked (e.g. Weibull's Evolutionary Game Theory and Björk's Arbitrage Theory in Continuous Time)